### PR TITLE
Provide an opt out of setting focus

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -76,8 +76,6 @@ function Tabs(rootEl) {
 
 		// Scroll back to the original position
 		window.scrollTo(x, y);
-
-
 	}
 
 	function dispatchCustomEvent(name, data) {

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -56,25 +56,27 @@ function Tabs(rootEl) {
 		panelEl.setAttribute('aria-hidden', 'true');
 	}
 
-	function showPanel(panelEl, focusReq) {
+	function showPanel(panelEl, disableFocus) {
 		panelEl.setAttribute('aria-expanded', 'true');
 		panelEl.setAttribute('aria-hidden', 'false');
 
 		// Remove the focus ring for sighted users
 		panelEl.style.outline = 0;
 
-		if(focusReq === false || focusReq === 'undefined'){
-			// Get current scroll position
-			var x = window.scrollX;
-			var y = window.scrollY;
-
-			// Give focus to the panel for screen readers
-			// This might cause the browser to scroll up or down
-			panelEl.focus();
-
-			// Scroll back to the original position
-			window.scrollTo(x, y);
+		if(disableFocus){
+			return;
 		}
+		// Get current scroll position
+		var x = window.scrollX;
+		var y = window.scrollY;
+
+		// Give focus to the panel for screen readers
+		// This might cause the browser to scroll up or down
+		panelEl.focus();
+
+		// Scroll back to the original position
+		window.scrollTo(x, y);
+
 
 	}
 
@@ -89,13 +91,13 @@ function Tabs(rootEl) {
 		}
 	}
 
-	function selectTab(i, focusReq) {
+	function selectTab(i, disableFocus) {
 		var c, l;
 		if (isValidTab(i) && i !== selectedTabIndex) {
 			for (c = 0, l = tabEls.length; c < l; c++) {
 				if (i === c) {
 					tabEls[c].setAttribute('aria-selected', 'true');
-					showPanel(tabpanelEls[c], focusReq);
+					showPanel(tabpanelEls[c], disableFocus);
 				} else {
 					tabEls[c].setAttribute('aria-selected', 'false');
 					hidePanel(tabpanelEls[c]);

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -63,7 +63,7 @@ function Tabs(rootEl) {
 		// Remove the focus ring for sighted users
 		panelEl.style.outline = 0;
 
-		if(focusReq === false || focusReq =='undefined'){
+		if(focusReq === false || focusReq === 'undefined'){
 			// Get current scroll position
 			var x = window.scrollX;
 			var y = window.scrollY;

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -16,7 +16,10 @@ function Tabs(rootEl) {
 	}
 
 	function getTabPanelEls(tabEls) {
-		var els = [], targetEl, c, l;
+		var els = [];
+		var targetEl;
+		var c;
+		var l;
 		for (c = 0, l = tabEls.length; c < l; c++) {
 			var tabTargetId = getTabTargetId(tabEls[c]);
 			targetEl = document.getElementById(tabTargetId);
@@ -90,7 +93,8 @@ function Tabs(rootEl) {
 	}
 
 	function selectTab(i, disableFocus) {
-		var c, l;
+		var c;
+		var l;
 		if (isValidTab(i) && i !== selectedTabIndex) {
 			for (c = 0, l = tabEls.length; c < l; c++) {
 				if (i === c) {
@@ -150,7 +154,10 @@ function Tabs(rootEl) {
 }
 
 Tabs.init = function(el) {
-	var tabs = [], tEls, c, l;
+	var tabs = [];
+	var tEls;
+	var c;
+	var l;
 	if (!el) {
 		el = document.body;
 	} else if (!(el instanceof HTMLElement)) {

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -56,23 +56,26 @@ function Tabs(rootEl) {
 		panelEl.setAttribute('aria-hidden', 'true');
 	}
 
-	function showPanel(panelEl) {
+	function showPanel(panelEl, focusReq) {
 		panelEl.setAttribute('aria-expanded', 'true');
 		panelEl.setAttribute('aria-hidden', 'false');
 
 		// Remove the focus ring for sighted users
 		panelEl.style.outline = 0;
 
-		// Get current scroll position
-		var x = window.scrollX;
-		var y = window.scrollY;
+		if(focusReq === false || focusReq =='undefined'){
+			// Get current scroll position
+			var x = window.scrollX;
+			var y = window.scrollY;
 
-		// Give focus to the panel for screen readers
-		// This might cause the browser to scroll up or down
-		panelEl.focus();
+			// Give focus to the panel for screen readers
+			// This might cause the browser to scroll up or down
+			panelEl.focus();
 
-		// Scroll back to the original position
-		window.scrollTo(x, y);
+			// Scroll back to the original position
+			window.scrollTo(x, y);
+		}
+
 	}
 
 	function dispatchCustomEvent(name, data) {
@@ -86,13 +89,13 @@ function Tabs(rootEl) {
 		}
 	}
 
-	function selectTab(i) {
+	function selectTab(i, focusReq) {
 		var c, l;
 		if (isValidTab(i) && i !== selectedTabIndex) {
 			for (c = 0, l = tabEls.length; c < l; c++) {
 				if (i === c) {
 					tabEls[c].setAttribute('aria-selected', 'true');
-					showPanel(tabpanelEls[c]);
+					showPanel(tabpanelEls[c], focusReq);
 				} else {
 					tabEls[c].setAttribute('aria-selected', 'false');
 					hidePanel(tabpanelEls[c]);


### PR DESCRIPTION
@kaelig @jamesnicholls 
This is my suggestion for making the focus optional on the tabs. Clearly for accesibility focus is required but there is a case for setting aria-selected in the background  where focus on the element may not be desired. 

The background to this request is having discovered a bit of an edge case where the scrolling on focus still gets triggered on the sign-up-app when integrated into app.ft.com. I think this is becuase the form is loaded into an iframe. The scrollTo is applied to the iframe which has scroll disabled. So scroll events in this context are handled by the app using postMessage. So this could be a route to solving this case however it might be better to have the option to make focus optional on a wider basis.