### PR TITLE
Add o-tracking integration and refactor dispatchCustomEvent() helper

### DIFF
--- a/demos/base-style.html
+++ b/demos/base-style.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<!--[if IE 7]>         <html class="o-useragent-ie7 o-hoverable-on"> <![endif]-->
-<!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
+<html class="o-hoverable-on o-hoverable-on">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-tabs: base-style demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:queryselector,modernizr:addeventlistener,modernizr:classlist,modernizr:domcontentready,modernizr:customevent,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=queryselector,addeventlistener,classlist,domcontentready,customevent,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-tabs:/demos/src/demo.scss" />
 </head>
-<body class="o-hoverable-on">
+<body>
 <ul data-o-component="o-tabs" class="o-tabs" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>

--- a/demos/buttontabs-big.html
+++ b/demos/buttontabs-big.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<!--[if IE 7]>         <html class="o-useragent-ie7 o-hoverable-on"> <![endif]-->
-<!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
+<html class="o-hoverable-on o-hoverable-on">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-tabs: buttontabs-big demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:queryselector,modernizr:addeventlistener,modernizr:classlist,modernizr:domcontentready,modernizr:customevent,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=queryselector,addeventlistener,classlist,domcontentready,customevent,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-tabs:/demos/src/demo.scss" />
 </head>
-<body class="o-hoverable-on">
+<body>
 <ul data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>

--- a/demos/buttontabs.html
+++ b/demos/buttontabs.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<!--[if IE 7]>         <html class="o-useragent-ie7 o-hoverable-on"> <![endif]-->
-<!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
+<html class="o-hoverable-on o-hoverable-on">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 	<title>o-tabs: buttontabs demo</title>
 	<meta name="viewport" content="initial-scale=1.0, width=device-width" />
-	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=modernizr:queryselector,modernizr:addeventlistener,modernizr:classlist,modernizr:domcontentready,modernizr:customevent,default"></script>
+	<script src="//polyfill.webservices.ft.com/v1/polyfill.min.js?features=queryselector,addeventlistener,classlist,domcontentready,customevent,default"></script>
 	<style>body { margin: 0; } .demo-js .o--if-nojs { display: none; }</style>
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-tabs:/demos/src/demo.scss" />
 </head>
-<body class="o-hoverable-on">
+<body>
 <ul data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -82,7 +82,7 @@ function Tabs(rootEl) {
 
 	function dispatchCustomEvent(event, data = {}, namespace = 'oTabs') {
 		rootEl.dispatchEvent(new CustomEvent(namespace + '.' + event, {
-			detail: data || {},
+			detail: data,
 			bubbles: true
 		}));
 	}

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -80,15 +80,11 @@ function Tabs(rootEl) {
 		window.scrollTo(x, y);
 	}
 
-	function dispatchCustomEvent(name, data) {
-		if (document.createEvent && rootEl.dispatchEvent) {
-			const event = document.createEvent('Event');
-			event.initEvent(name, true, true);
-			if (data) {
-				event.detail = data;
-			}
-			rootEl.dispatchEvent(event);
-		}
+	function dispatchCustomEvent(event, data = {}, namespace = 'oTabs') {
+		rootEl.dispatchEvent(new CustomEvent(namespace + '.' + event, {
+			detail: data || {},
+			bubbles: true
+		}));
 	}
 
 	function selectTab(i, disableFocus) {
@@ -104,7 +100,7 @@ function Tabs(rootEl) {
 					hidePanel(tabpanelEls[c]);
 				}
 			}
-			dispatchCustomEvent('oTabs.tabSelect', {
+			dispatchCustomEvent('tabSelect', {
 				tabs: tabsObj,
 				selected: i,
 				lastSelected: selectedTabIndex
@@ -119,6 +115,11 @@ function Tabs(rootEl) {
 		if (tabEl) {
 			const i = getTabIndexFromElement(tabEl);
 			myself.selectTab(i);
+			dispatchCustomEvent('event', {
+				category: 'tabs',
+				action: 'click',
+				tab: tabEl.textContent
+			}, 'oTracking');
 		}
 	}
 
@@ -132,7 +133,7 @@ function Tabs(rootEl) {
 		tabpanelEls = getTabPanelEls(tabEls);
 		rootEl.setAttribute('data-o-tabs--js', '');
 		rootEl.addEventListener("click", clickHandler, false);
-		dispatchCustomEvent('oTabs.ready', {
+		dispatchCustomEvent('ready', {
 			tabs: tabsObj
 		});
 		myself.selectTab(getSelectedTabElement());


### PR DESCRIPTION
- Adds o-tracking integration on tab clicks. It tracks the text content of the tab, let me know if it should track the anchor (id) on the tab instead.
- Refactored `dispatchCustomEvent()` because `event.initEvent` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent).

CC @AlbertoElias 