### PR TITLE
Added fallback for 'scrollX' and 'scrollY'

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -69,8 +69,8 @@ function Tabs(rootEl) {
 			return;
 		}
 		// Get current scroll position
-		const x = window.scrollX;
-		const y = window.scrollY;
+		const x = window.scrollX || window.pageXOffset;
+		const y = window.scrollY || window.pageYOffset;
 
 		// Give focus to the panel for screen readers
 		// This might cause the browser to scroll up or down


### PR DESCRIPTION
 Added 'pageXOffset' and 'pageYOffset' as a fallback for 'scrollX' and 'scrollY' to prevent the page jumping back to the top on click of a tab in IE. Tested and working in IE11.