### PR TITLE
data-o-tabs-autoconstruct="false" does not prevent auto-initialisation

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -165,7 +165,7 @@ Tabs.init = function(el) {
 	if (el.querySelectorAll) {
 		tEls = el.querySelectorAll('[data-o-component=o-tabs]');
 		for (c = 0, l = tEls.length; c < l; c++) {
-			if (!tEls[c].matches('[data-o-tabs-autoconstruct=false]') || !tEls[c].hasAttribute('data-o-tabs--js')) {
+			if (!tEls[c].matches('[data-o-tabs-autoconstruct=false]') && !tEls[c].hasAttribute('data-o-tabs--js')) {
 				tabs.push(new Tabs(tEls[c]));
 			}
 		}

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -116,4 +116,14 @@ describe("tabs behaviour", () => {
 
 	});
 
+	it("does not auto initialise when 'data-o-tabs-autoconstruct=false' is set", () => {
+		fixtures.reset();
+
+		fixtures.insertSimple();
+		tabsEl = document.querySelector('[data-o-component=o-tabs]');
+		tabsEl.setAttribute('data-o-tabs-autoconstruct', 'false');
+		Tabs.init();
+		expect(tabsEl.hasAttribute('data-o-tabs--js')).toBe(false);
+	});
+
 });


### PR DESCRIPTION
If the 'data-o-tabs-autoconstruct' attribute is set to false the tabs still initialise when using the static Tabs.init method (called as a result of the 'o.DOMContentLoaded' event). I've added a test for this and a fix.