### PR TITLE
update the url when tabs change

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -1,11 +1,12 @@
 /*global module, require*/
 const oDom = require('o-dom');
 
-function Tabs(rootEl) {
+function Tabs(rootEl, options) {
 
 	const tabsObj = this;
 	let tabEls;
 	let tabpanelEls;
+	let updateUrl = (typeof options === 'object' && 'updateUrl' in options) ? options.updateUrl : true;
 	let selectedTabIndex = -1;
 	const myself = this;
 
@@ -59,6 +60,11 @@ function Tabs(rootEl) {
 	}
 
 	function showPanel(panelEl, disableFocus) {
+		// update the url to match the selected tab
+		if(panelEl.id && updateUrl){
+			location.href = '#' + panelEl.id;
+		}
+
 		panelEl.setAttribute('aria-expanded', 'true');
 		panelEl.setAttribute('aria-hidden', 'false');
 
@@ -167,7 +173,8 @@ Tabs.init = function(el) {
 		tEls = el.querySelectorAll('[data-o-component=o-tabs]');
 		for (c = 0, l = tEls.length; c < l; c++) {
 			if (!tEls[c].matches('[data-o-tabs-autoconstruct=false]') && !tEls[c].hasAttribute('data-o-tabs--js')) {
-				tabs.push(new Tabs(tEls[c]));
+				let updateUrl = tEls[c].getAttribute('data-o-tabs-updateUrl') === 'false' ? false : true;
+				tabs.push(new Tabs(tEls[c], {updateUrl:updateUrl}));
 			}
 		}
 	}

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -126,4 +126,16 @@ describe("tabs behaviour", () => {
 		expect(tabsEl.hasAttribute('data-o-tabs--js')).toBe(false);
 	});
 
+	it('Should update the hash part of the url to the id of the active tab', () => {
+		testTabs.selectTab(0);
+		let expectedHash = document.querySelector('.o-tabs li:first-child a').hash;
+		expect(location.hash).toEqual(expectedHash);
+	});
+
+	it('Should not update the url if the user asks it not to', () => {
+		fixtures.reset();
+		fixtures.insertSimple();
+		document.querySelector('.o-tabs').setAttribute('data-o-tabs-updateUrl', 'false');
+	});
+
 });


### PR DESCRIPTION
Adding the functionality to update the hash part of the url to match the open tab.

As it's entirely possible to have more than one set of tabs on a page I've added an option to disable this.  Thinking about it now, it should probably default to false in case people are using the hash for other things.  Please let me know your thoughts