### PR TITLE
make hash update opt-in and respond to hashchange events

### DIFF
--- a/demos/base-style.html
+++ b/demos/base-style.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="/bundles/css?modules=o-tabs:/demos/src/demo.scss" />
 </head>
 <body>
-<ul data-o-component="o-tabs" class="o-tabs" role="tablist">
+<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab"><a href="#tabContent3">Tab 3</a></li>

--- a/demos/src/base-style.mustache
+++ b/demos/src/base-style.mustache
@@ -1,4 +1,4 @@
-<ul data-o-component="o-tabs" class="o-tabs" role="tablist">
+<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-update-url>
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab"><a href="#tabContent3">Tab 3</a></li>

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -6,7 +6,7 @@ function Tabs(rootEl, options) {
 	const tabsObj = this;
 	let tabEls;
 	let tabpanelEls;
-	let updateUrl = (typeof options === 'object' && 'updateUrl' in options) ? options.updateUrl : true;
+	let updateUrl = (rootEl.getAttribute('data-o-tabs-update-url') !== null);
 	let selectedTabIndex = -1;
 	const myself = this;
 
@@ -41,13 +41,22 @@ function Tabs(rootEl, options) {
 		return els;
 	}
 
+	function getTabElementFromHash(){
+		const tabLink = rootEl.querySelector(`[href="${location.hash}"]`);
+		return tabLink && tabLink.parentNode ? tabLink.parentNode : null;
+	}
+
 	function getTabIndexFromElement(el) {
 		return oDom.getIndex(el);
 	}
 
-	function getSelectedTabElement() {
-		const selectedTabEl = rootEl.querySelector('[aria-selected=true]');
-		return (selectedTabEl) ? getTabIndexFromElement(selectedTabEl) : 0;
+	function getSelectedTabElement(){
+		return rootEl.querySelector('[aria-selected=true]');
+	}
+
+	function getSelectedTabIndex() {
+		const selectedTabElement = updateUrl && location.hash ? getTabElementFromHash() : getSelectedTabElement()
+		return selectedTabElement ? getTabIndexFromElement(selectedTabElement) : 0;
 	}
 
 	function isValidTab(i) {
@@ -119,14 +128,29 @@ function Tabs(rootEl, options) {
 		ev.preventDefault();
 		const tabEl = oDom.getClosestMatch(ev.target, '[role=tab]');
 		if (tabEl) {
-			const i = getTabIndexFromElement(tabEl);
-			myself.selectTab(i);
-			dispatchCustomEvent('event', {
-				category: 'tabs',
-				action: 'click',
-				tab: tabEl.textContent
-			}, 'oTracking');
+			updateCurrentTab(tabEl);
 		}
+	}
+
+	function hashChangeHandler() {
+		if(!updateUrl){
+			return;
+		}
+
+		const tabEl = getTabElementFromHash();
+		if(tabEl){
+			updateCurrentTab(tabEl);
+		}
+	}
+
+	function updateCurrentTab(tabEl){
+		const i = getTabIndexFromElement(tabEl);
+		myself.selectTab(i);
+		dispatchCustomEvent('event', {
+			category: 'tabs',
+			action: 'click',
+			tab: tabEl.textContent
+		}, 'oTracking');
 	}
 
 	function init() {
@@ -139,14 +163,17 @@ function Tabs(rootEl, options) {
 		tabpanelEls = getTabPanelEls(tabEls);
 		rootEl.setAttribute('data-o-tabs--js', '');
 		rootEl.addEventListener("click", clickHandler, false);
+		window.addEventListener('hashchange', hashChangeHandler, false);
 		dispatchCustomEvent('ready', {
 			tabs: tabsObj
 		});
-		myself.selectTab(getSelectedTabElement());
+
+		myself.selectTab(getSelectedTabIndex());
 	}
 
 	function destroy() {
 		rootEl.removeEventListener("click", clickHandler, false);
+		window.removeEventListener("hashchange", hashChangeHandler, false);
 		rootEl.removeAttribute('data-o-tabs--js');
 		for (let c = 0, l = tabpanelEls.length; c < l; c++) {
 			showPanel(tabpanelEls[c]);
@@ -173,8 +200,7 @@ Tabs.init = function(el) {
 		tEls = el.querySelectorAll('[data-o-component=o-tabs]');
 		for (c = 0, l = tEls.length; c < l; c++) {
 			if (!tEls[c].matches('[data-o-tabs-autoconstruct=false]') && !tEls[c].hasAttribute('data-o-tabs--js')) {
-				let updateUrl = tEls[c].getAttribute('data-o-tabs-updateUrl') === 'false' ? false : true;
-				tabs.push(new Tabs(tEls[c], {updateUrl:updateUrl}));
+				tabs.push(new Tabs(tEls[c]));
 			}
 		}
 	}

--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -1,7 +1,7 @@
 /*global module, require*/
 const oDom = require('o-dom');
 
-function Tabs(rootEl, options) {
+function Tabs(rootEl) {
 
 	const tabsObj = this;
 	let tabEls;
@@ -55,7 +55,7 @@ function Tabs(rootEl, options) {
 	}
 
 	function getSelectedTabIndex() {
-		const selectedTabElement = updateUrl && location.hash ? getTabElementFromHash() : getSelectedTabElement()
+		const selectedTabElement = updateUrl && location.hash ? getTabElementFromHash() : getSelectedTabElement();
 		return selectedTabElement ? getTabIndexFromElement(selectedTabElement) : 0;
 	}
 

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -126,16 +126,54 @@ describe("tabs behaviour", () => {
 		expect(tabsEl.hasAttribute('data-o-tabs--js')).toBe(false);
 	});
 
-	it('Should update the hash part of the url to the id of the active tab', () => {
-		testTabs.selectTab(0);
-		let expectedHash = document.querySelector('.o-tabs li:first-child a').hash;
-		expect(location.hash).toEqual(expectedHash);
-	});
+	describe('hash updating', () => {
 
-	it('Should not update the url if the user asks it not to', () => {
-		fixtures.reset();
-		fixtures.insertSimple();
-		document.querySelector('.o-tabs').setAttribute('data-o-tabs-updateUrl', 'false');
-	});
+		const rebuildTabs = (withUpdateUrl = true) => {
+			fixtures.reset();
+			fixtures.insertSimple();
+			withUpdateUrl && tabsEl.setAttribute('data-o-tabs-update-url', '');
+			testTabs.destroy();
+			testTabs = new Tabs(tabsEl);
+		};
 
+		beforeEach(() => {
+			location.hash = '';
+		});
+
+		afterEach(() => {
+			tabsEl.removeAttribute('data-o-tabs-update-url');
+		});
+
+		it('Should update the hash part of the url to the id of the active tab', () => {
+			rebuildTabs();
+			testTabs.selectTab(0);
+			let expectedHash = document.querySelector('.o-tabs li:first-child a').hash;
+			expect(location.hash).toEqual(expectedHash);
+		});
+
+		it('Should not update the url if the data attribute is not present', () => {
+			rebuildTabs(false);
+			testTabs.selectTab(0);
+			expect(location.hash).toEqual('');
+		});
+
+		it('Should open the correct tab onload if the hash is present', (done) => {
+			location.hash = '#tabContent3';
+			tabsEl.addEventListener('oTabs.tabSelect', (ev) => {
+				expect(ev.detail.selected).toBe(2);
+				done();
+			});
+			rebuildTabs();
+		});
+
+		it('Should respond to the hashchange event', (done) => {
+			rebuildTabs();
+			testTabs.selectTab(0);
+			location.hash = '#tabContent3';
+			tabsEl.addEventListener('oTabs.tabSelect', (ev) => {
+				expect(ev.detail.selected).toBe(2);
+				done();
+			});
+		});
+	});
 });


### PR DESCRIPTION
Now setting hash is off by default to avoid conflicts.  It also responds to hashchange events and is better implemented