### PR TITLE
Move url update to after disablefocus check

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -68,11 +68,6 @@ function Tabs(rootEl, config) {
 	}
 
 	function showPanel(panelEl, disableFocus) {
-		// update the url to match the selected tab
-		if(panelEl.id && updateUrl){
-			location.href = '#' + panelEl.id;
-		}
-
 		panelEl.setAttribute('aria-expanded', 'true');
 		panelEl.setAttribute('aria-hidden', 'false');
 
@@ -82,6 +77,12 @@ function Tabs(rootEl, config) {
 		if (disableFocus){
 			return;
 		}
+
+		// update the url to match the selected tab
+		if(panelEl.id && updateUrl){
+			location.href = '#' + panelEl.id;
+		}
+
 		// Get current scroll position
 		const x = window.scrollX || window.pageXOffset;
 		const y = window.scrollY || window.pageYOffset;

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -136,6 +136,7 @@ describe('tabs behaviour', () => {
 			fixtures.reset();
 			fixtures.insertSimple();
 			withUpdateUrl && tabsEl.setAttribute('data-o-tabs-update-url', '');
+			tabsEl.setAttribute('data-o-tabs-disablefocus', 'false');
 			testTabs.destroy();
 			testTabs = new Tabs(tabsEl);
 		};

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -21,7 +21,7 @@ function insert(html) {
 
 function insertSimple() {
 	const html = `
-		<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-disableFocus="true">
+		<ul data-o-component="o-tabs" class="o-tabs" role="tablist" data-o-tabs-disablefocus="true">
 			<li role="tab" class="should-be-focusable"><a href="#tabContent1" class="should-not-be-focusable">Tab 1</a></li>
 			<li role="tab" class="should-be-focusable"><a href="#tabContent2" class="should-not-be-focusable">Tab 2</a></li>
 			<li role="tab" class="should-be-focusable"><a href="#tabContent3" class="should-not-be-focusable">Tab 3</a></li>


### PR DESCRIPTION
Updates the `showPanel` function to move setting the URL below the `disablefocus` check.

This means that `disablefocus` will take precedence over the `updateUrl` setting, which I think makes sense as if you want to disable focus on the element you can't have the `#` in the URL as browsers will do that for you.

Fixes #29 