### PR TITLE
Enable: Keyboard user accessibility

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -132,6 +132,15 @@ function Tabs(rootEl, config) {
 		}
 	}
 
+	function keyPressHandler(ev) {
+		ev.preventDefault();
+		const tabEl = oDom.getClosestMatch(ev.target, '[role=tab]');
+		// Only update if key pressed is enter key
+		if (tabEl && ev.keyCode === 13) {
+			updateCurrentTab(tabEl);
+		}
+	}
+
 	function hashChangeHandler() {
 		if(!updateUrl){
 			return;
@@ -163,6 +172,7 @@ function Tabs(rootEl, config) {
 		tabpanelEls = getTabPanelEls(tabEls);
 		rootEl.setAttribute('data-o-tabs--js', '');
 		rootEl.addEventListener('click', clickHandler, false);
+		rootEl.addEventListener('keypress', keyPressHandler, false);
 		window.addEventListener('hashchange', hashChangeHandler, false);
 
 		if (!config) {

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -99,6 +99,22 @@ describe('tabs behaviour', () => {
 
 	});
 
+	it('enter key press tab', () => {
+		spyOn(testTabs, 'selectTab');
+		const keyPressEvent = document.createEvent('Event');
+		keyPressEvent.keyCode = 13;
+		keyPressEvent.initEvent('keypress', true, true);
+
+		tabsEl.querySelectorAll('li a')[2].dispatchEvent(keyPressEvent);
+		expect(testTabs.selectTab).toHaveBeenCalledWith(2);
+
+		tabsEl.querySelectorAll('li a')[1].dispatchEvent(keyPressEvent);
+		expect(testTabs.selectTab).toHaveBeenCalledWith(1);
+
+		tabsEl.querySelectorAll('li a')[0].dispatchEvent(keyPressEvent);
+		expect(testTabs.selectTab).toHaveBeenCalledWith(0);
+	});
+
 	it('destroy()', () => {
 		testTabs.destroy();
 


### PR DESCRIPTION
cc @onishiweb @JakeChampion 

Allows tabs to be presented using return key (rather than requiring a click).