### PR TITLE
Tabs V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Tabs component for dividing content into meaningful sections.
 	- [Markup](#markup)
 	- [JavaScript](#javascript)
 	- [Sass](#sass)
+- [Migration guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
 
@@ -165,6 +166,16 @@ If you're using the Sass mixins, you can also theme o-tabs using the `oTabsButto
 @include oTabsButtonTabsTheme('inverse');
 ```
 
+## Migration Guide
+
+### Migrating from v3 to v4
+
+This major includes the new o-colors and o-buttons, and updates the themes and sizes of button tabs.
+
+The following changes have been made to the **themes**:
+
+- `Standout` is now `Primary`: use `oTabsButtonTabsTheme('primary')`
+- `Uncolored` is now `Mono`: use `oTabsButtonTabsTheme('mono')`
 
 ---
 

--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,8 @@
 		".gitignore"
 	],
 	"dependencies": {
-		"o-colors": ">=2.3.11 <4",
-		"o-buttons": ">=1.8.0 <5",
-		"o-dom": ">=0.3.0 <3"
+		"o-colors": "^4.0.2",
+		"o-buttons": "^5.0.0",
+		"o-dom": "^2.0.3"
 	}
 }

--- a/demos/src/buttontabs-primary.mustache
+++ b/demos/src/buttontabs-primary.mustache
@@ -1,4 +1,4 @@
-<ul data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs o-tabs--standout" role="tablist">
+<ul data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs o-tabs--primary" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab" aria-selected="true"><a href="#tabContent3">Tab 3</a></li>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -14,5 +14,5 @@ body {
 }
 
 // Include for demos of the themeable tabs
-@include oTabsButtonTabsTheme('standout');
+@include oTabsButtonTabsTheme('primary');
 @include oTabsButtonTabsTheme('inverse');

--- a/main.scss
+++ b/main.scss
@@ -1,5 +1,4 @@
 @import 'o-colors/main';
-@import 'o-hoverable/main';
 @import 'o-buttons/main';
 
 @import 'src/scss/variables';

--- a/origami.json
+++ b/origami.json
@@ -42,8 +42,8 @@
 			"description": ""
 		},
 		{
-			"name": "buttontabs-standout",
-			"template": "demos/src/buttontabs-standout.mustache",
+			"name": "buttontabs-primary",
+			"template": "demos/src/buttontabs-primary.mustache",
 			"description": "",
 			"hidden": true
 		},

--- a/src/scss/buttontabs.scss
+++ b/src/scss/buttontabs.scss
@@ -1,7 +1,7 @@
 @mixin oTabsButtonTabs() {
 	.o-tabs--buttontabs[data-o-tabs--js] {
 		&[role=tablist] {
-			border-bottom: 1px solid oColorsGetColorFor(o-buttons-standard-normal, border);
+			border-bottom: 1px solid oColorsGetColorFor(o-buttons-secondary-normal, border);
 			font-size: 0; // Hack to remove the spacing between tabs when using <li>'s
 		}
 


### PR DESCRIPTION
This is the work required to bump o-tabs to v4. I've made the necessary changes but there are two more things to consider:

1. ~Whether I need to include #19~
2. ~Whether the design needs tweaking a little~

Using o-buttons v5 means that the borders on the active tab are not visible by default, as the background colour matches it. I've added some comparison screen-shots:

| V3                                                                                                                          | V4                                                                                                                          |
|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
| ![old-default](https://user-images.githubusercontent.com/138944/26873557-2926c56c-4b72-11e7-8781-31cbeef82e07.png)          | ![new-default](https://user-images.githubusercontent.com/138944/26873565-2e406a4e-4b72-11e7-9f4f-8a913cf60a07.png)          |
| ![old-standout-primary](https://user-images.githubusercontent.com/138944/26873556-2924c67c-4b72-11e7-9907-aa83292c3b64.png) | ![new-standout-primary](https://user-images.githubusercontent.com/138944/26873567-2e47936e-4b72-11e7-9b15-e14d3b4ad405.png) |
| ![old-big](https://user-images.githubusercontent.com/138944/26873555-29234414-4b72-11e7-8b46-c9abc127a013.png)              | ![new-big](https://user-images.githubusercontent.com/138944/26873566-2e4565c6-4b72-11e7-9138-9023bef4eea8.png)              |
| ![old-inverse](https://user-images.githubusercontent.com/138944/26873558-29271364-4b72-11e7-8b2e-4b2f1bfb6585.png)          | ![new-inverse](https://user-images.githubusercontent.com/138944/26873564-2e3f9588-4b72-11e7-858e-88f85323bb98.png)          |

What do people think?
