### PR TITLE
Prevent errors for "fake" tabs which have external links.

### DIFF
--- a/src/js/Tabs.js
+++ b/src/js/Tabs.js
@@ -12,6 +12,7 @@ class Tabs {
 
 
 		this.tabEls = this.rootEl.querySelectorAll('[role=tab]');
+		this.tabEls = [].slice.call(this.tabEls).filter(this.tabHasValidUrl);
 		this.tabpanelEls = this.getTabPanelEls(this.tabEls);
 
 		this.boundClickHandler = this.clickHandler.bind(this);
@@ -163,19 +164,19 @@ class Tabs {
 	};
 
 	clickHandler(ev) {
-		ev.preventDefault();
 		const tabEl = oDom.getClosestMatch(ev.target, '[role=tab]');
 
-		if (tabEl) {
+		if (tabEl && this.tabHasValidUrl(tabEl)) {
+			ev.preventDefault();
 			this.updateCurrentTab(tabEl);
 		}
 	};
 
 	keyPressHandler(ev) {
-		ev.preventDefault();
 		const tabEl = oDom.getClosestMatch(ev.target, '[role=tab]');
 		// Only update if key pressed is enter key
-		if (tabEl && ev.keyCode === 13) {
+		if (tabEl && ev.keyCode === 13 && this.tabHasValidUrl(tabEl)) {
+			ev.preventDefault();
 			this.updateCurrentTab(tabEl);
 		}
 	};
@@ -201,6 +202,14 @@ class Tabs {
 			tab: tabEl.textContent.trim()
 		}, 'oTracking');
 	};
+
+	tabHasValidUrl(tabEl) {
+		const linkEls = tabEl.getElementsByTagName('a');
+		if (! linkEls || ! linkEls[0].hash) {
+			return false;
+		}
+		return linkEls[0].pathname === location.pathname;
+	}
 
 	destroy() {
 		this.rootEl.removeEventListener('click', this.boundClickHandler, false);

--- a/src/scss/buttontabs.scss
+++ b/src/scss/buttontabs.scss
@@ -7,10 +7,6 @@
 
 		[role=tab] {
 			@include oButtons;
-
-			a {
-				pointer-events: none;
-			}
 		}
 
 		&.o-tabs--big [role=tab] {


### PR DESCRIPTION
Whilst no longer erroring this approach is not recommended on semantic/accessibility grounds; aria attributes are maintained.
https://github.com/Financial-Times/o-tabs/issues/54

E.g.
```
<ul data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs" role="tablist">
	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
	<li role="tab" aria-selected="true"><a href="https://google.co.uk">Tab 3</a></li>
</ul>
<div id="tabContent1" class="o-tabs__tabpanel">
	<h3>Tab content 1</h3>
	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nostrum, ipsum.</p>
</div>
<div id="tabContent2" class="o-tabs__tabpanel">
	<h3>Tab content 2</h3>
	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nostrum, ipsum.</p>
</div>
```