### PR TITLE
Add brand support to o-tabs.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
 	],
 	"dependencies": {
 		"o-colors": "^4.0.2",
-		"o-buttons": "^5.0.0",
+		"o-buttons": "^5.10.1",
 		"o-dom": "^2.0.3"
 	}
 }

--- a/demos/src/buttontabs-inverse.mustache
+++ b/demos/src/buttontabs-inverse.mustache
@@ -1,6 +1,6 @@
 <div class="container-inverse">
 
-<ul data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs o-tabs--inverse" role="tablist">
+<ul data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--inverse" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab" aria-selected="true"><a href="#tabContent3">Tab 3</a></li>

--- a/demos/src/buttontabs-primary.mustache
+++ b/demos/src/buttontabs-primary.mustache
@@ -1,4 +1,4 @@
-<ul data-o-component="o-tabs" class="o-tabs o-tabs--big o-tabs--buttontabs o-tabs--primary" role="tablist">
+<ul data-o-component="o-tabs" class="o-tabs o-tabs--buttontabs o-tabs--primary" role="tablist">
 	<li role="tab"><a href="#tabContent1">Tab 1</a></li>
 	<li role="tab"><a href="#tabContent2">Tab 2</a></li>
 	<li role="tab" aria-selected="true"><a href="#tabContent3">Tab 3</a></li>

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -12,7 +12,3 @@ body {
 	color: #ffffff;
 	background: #333333;
 }
-
-// Include for demos of the themeable tabs
-@include oTabsButtonTabsTheme('primary');
-@include oTabsButtonTabsTheme('inverse');

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,7 @@
 @import 'o-colors/main';
 @import 'o-buttons/main';
 
+@import 'src/scss/brand';
 @import 'src/scss/variables';
 @import 'src/scss/mixins';
 @import 'src/scss/buttontabs';
@@ -8,4 +9,9 @@
 @if $o-tabs-is-silent == false {
 	@include oTabs;
 	@include oTabsButtonTabs;
+
+	// Output themes.
+	@each $key, $theme in $o-tabs-themes {
+		@include oTabsButtonTabsTheme($theme);
+	}
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,20 @@
+@include oBrandDefine('o-tabs', 'master', (
+    'variables': (),
+    'settings': (
+        'primary': true,
+        'inverse': true
+    )
+));
+
+@include oBrandDefine('o-tabs', 'internal', (
+    'variables': (),
+    'settings': (
+        'primary': true,
+        'inverse': true
+    )
+));
+
+@include oBrandDefine('o-tabs', 'whitelabel', (
+    'variables': (),
+    'settings': ()
+));

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -6,3 +6,13 @@
 /// Silent mode
 /// @type Bool
 $o-tabs-is-silent: true !default;
+
+/// Tab themes to a corresponding brand variant.
+/// Must be a supported o-buttons theme.
+/// Other themes avalible, see o-buttons themes.
+///
+/// @type Map
+$o-tabs-themes: (
+	primary: 'primary',
+	inverse: 'inverse'
+) !default;

--- a/src/scss/buttontabs.scss
+++ b/src/scss/buttontabs.scss
@@ -1,12 +1,14 @@
+/// Outputs tabs with a default theme 'secondary'.
+/// @access public
 @mixin oTabsButtonTabs() {
 	.o-tabs--buttontabs[data-o-tabs--js] {
 		&[role=tablist] {
-			border-bottom: 1px solid oColorsGetColorFor(o-buttons-secondary-normal, border);
+			border-bottom: 1px solid _oTabsGetTablistBorderColor($theme: 'secondary');
 			font-size: 0; // Hack to remove the spacing between tabs when using <li>'s
 		}
 
 		[role=tab] {
-			@include oButtons;
+			@include oButtons($theme: 'secondary');
 		}
 
 		&.o-tabs--big [role=tab] {
@@ -33,19 +35,51 @@
 	}
 }
 
+/// Outputs a modifier class to theme tabs.
+/// @access public
 @mixin oTabsButtonTabsTheme($theme) {
-	.o-tabs--#{$theme} {
-		@if map-has-key($o-buttons-themes, $theme) {
-			&.o-tabs--buttontabs.o-tabs--#{$theme} [role=tab] {
+	@include oBrandConfigureFor('o-tabs', $theme) {
+		$selector: _oTabsGetThemeSelector($theme, 'o-tabs');
+		.#{$selector} {
+			&.o-tabs--buttontabs [role=tab] {
 				@include oButtonsTheme($theme);
 			}
-
-			$buttonBackground: oColorsGetColorFor(o-buttons-#{$theme}-normal, background);
-			$border: oColorsGetColorFor(o-buttons-#{$theme}-normal, border, $options: (default: $buttonBackground));
-
 			&.o-tabs--buttontabs[data-o-tabs--js][role=tablist] {
-				border-bottom: 1px solid $border;
+				border-bottom: 1px solid _oTabsGetTablistBorderColor($theme);
 			}
 		}
 	}
+}
+
+/// Maps theme to class modifiers.
+///
+/// @example
+///  _oTabsGetThemeSelector('primary') // o-tabs--primary
+///  _oTabsGetThemeSelector('primary-inverse') // o-tabs--primary.o-tabs--inverse
+///
+/// @access private
+/// @param {String} $theme - One of $o-tabs-themes
+/// @param {String} $tab-class - The base button class e.g. o-tabs
+/// @return {String} CSS class selector without leading `.` e.g. o-tabs.o-tabs--inverse
+@function _oTabsGetThemeSelector($theme, $tab-class) {
+	$theme-selector: '';
+	@if length($theme) > 1 {
+		@each $theme-part in $theme {
+			$prepend: if($theme-selector == '', '', '#{$theme-selector}.');
+			$theme-selector: '#{$prepend}#{$tab-class}--#{$theme-part}';
+		}
+	} @else {
+		$theme-selector: '#{$tab-class}--#{$theme}';
+	}
+	@return $theme-selector;
+}
+
+/// Gets the tablist border color for a given theme.
+/// @access private
+/// @return {color}
+@function _oTabsGetTablistBorderColor($theme) {
+	$button-background: oButtonsGetColor($state: 'default', $property: 'background', $theme: $theme);
+	$button-border: oButtonsGetColor($state: 'default', $property: 'border', $theme: $theme);
+	$tablist-border: if($button-border and $button-border != transparent, $button-border, $button-background);
+	@return $tablist-border;
 }


### PR DESCRIPTION
- Includes 'primary' and 'inverse' variants via the build service.
- Master brand supports all possible tablist variants. As does the internal brand except the "b2c" variant. The whitelabel brand supports no variant and defaults to a black/white tab.

The function `_oTabsGetThemeSelector` enables `o-tabs` to support "primary inverse" variant if needed. I.e.
```
@include oTabsButtonTabsTheme(('primary', 'inverse')); 
// .o-tabs--primary.o-tabs--inverse {}
```