### PR TITLE
Make the "big" size button tabs a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,11 @@ The `oTabs` mixin is used to output base styles as well as styles for several of
 /* etc. */
 ```
 
-If you wish to specify more themes to output styles for, you can pass in options (see [themes](#themes) for available options):
+If you wish to specify more sizes and themes to output styles for, you can pass in options (see [sizes](#sizes) and [themes](#themes) for available options):
 
 ```scss
 @include oTabs($opts: (
+    'sizes': ('big'),
     'themes': ('mono')
 ));
 ```
@@ -182,11 +183,19 @@ If you wish to specify more themes to output styles for, you can pass in options
 }
 ```
 
+### Sizes
+
+This table outlines all of the possible sizes you can request in the [`oTabs` mixin](#mixin-otabs):
+
+| Size | Notes               | Brand support                |
+|------|---------------------|------------------------------|
+| big  | Included by default | master, internal, whitelabel |
+
 ### Themes
 
 This table outlines all of the possible themes you can request in the [`oTabs` mixin](#mixin-otabs). All of these are [themes in o-buttons](https://github.com/Financial-Times/o-buttons#themes):
 
-| Size      | Notes                                    | Brand support    |
+| Theme     | Notes                                    | Brand support    |
 |-----------|------------------------------------------|------------------|
 | secondary | Always defined – no need to include this | master, internal |
 | primary   | Included by default                      | master, internal |

--- a/main.scss
+++ b/main.scss
@@ -9,7 +9,7 @@
 
 /// Outputs all available features and styles for tabs.
 ///
-/// @param {Map} $opts ['themes': ('primary', 'inverse')] - Tab options including themes to output styles for.
+/// @param {Map} $opts [('sizes': ('big'), 'themes': ('primary', 'inverse'))] - Tab options including themes to output styles for.
 /// @output The output includes the `.o-tabs` class definition as well as class definitions for every variant.
 /// @example scss - All tab styles
 ///   @include oTabs();
@@ -17,15 +17,17 @@
 ///   @include oTabs($opts: ('themes': ('primary'));
 /// @access public
 @mixin oTabs($opts: (
+	'sizes': ('big'),
 	'themes': ('primary', 'inverse')
 )) {
+	$sizes: map-get($opts, 'sizes');
 	$themes: map-get($opts, 'themes');
 
 	// Include base styles
 	@include _oTabsBase();
 
 	// Include base button tabs styles
-	@include _oTabsButtonTabs();
+	@include _oTabsButtonTabs($sizes);
 
 	// Output default themes. Other themes avalible, see o-buttons themes.
 	@each $theme in $themes {

--- a/src/scss/_buttontabs.scss
+++ b/src/scss/_buttontabs.scss
@@ -2,7 +2,7 @@
 /// Outputs tabs with a default theme 'secondary'.
 ///
 /// @access private
-@mixin _oTabsButtonTabs() {
+@mixin _oTabsButtonTabs($sizes) {
 	.o-tabs--buttontabs[data-o-tabs--js] {
 		&[role=tablist] {
 			border-bottom: 1px solid _oTabsGetTablistBorderColor($theme: 'secondary');
@@ -13,10 +13,15 @@
 			@include oButtons($theme: 'secondary');
 		}
 
-		&.o-tabs--big [role=tab] {
-			@include oButtonsSize('big');
+		@if index($sizes, 'big') {
+			&.o-tabs--big [role=tab] {
+				@include oButtonsSize('big');
+			}
 		}
 
+		// Note: this "big" selector is not included in the condition above
+		// because it'd have a negative impact on readability. The "big" here
+		// has minimal impact on the output bundle size
 		[role=tab],
 		&.o-tabs--big [role=tab] {
 			border-bottom-width: 0;


### PR DESCRIPTION
After a discussion with Lee this morning, we decided that this would be
painful and/or breaking to change later. Now if you don't use large tabs
(quite a lot of places) you can reduce your output bundle size