### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -1,8 +1,7 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import * as fixtures from './helpers/fixtures';
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+import fixtures from './helpers/fixtures';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,6 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import fixtures from './helpers/fixtures';
 
 import Tabs from '../main';


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.