### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-import Tabs from './src/js/Tabs';
+import Tabs from './src/js/Tabs.js';
 
 const constructAll = function() {
 	Tabs.init();

--- a/test/Tabs.test.js
+++ b/test/Tabs.test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import fixtures from './helpers/fixtures';
+import fixtures from './helpers/fixtures.js';
 
 sinon.assert.expose(proclaim, {
 	includeFail: false,
 	prefix: ''
 });
 
-import Tabs from '../main';
+import Tabs from '../main.js';
 
 let testTabs;
 let tabsEl;

--- a/test/origami.test.js
+++ b/test/origami.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import fixtures from './helpers/fixtures';
+import fixtures from './helpers/fixtures.js';
 
-import Tabs from '../main';
+import Tabs from '../main.js';
 
 describe("Tabs", () => {
 	it('is defined', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing